### PR TITLE
Using the openswan public ip address instead of node[:ipadress]

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default['openswan']['ppp_link_network'] = "10.55.55.0"
 default['openswan']['preshared_key'] = "letmein"
 default['openswan']['private_virtual_interface_ip'] = "10.55.55.4"
+default['openswan']['public_ip'] = node['ipaddress']
 default['openswan']['private_ip'] = node['privateaddress']
 default['openswan']['private_ip_range'] = "10.55.55.5-10.55.55.100"
 default['openswan']['xl2tpd_path'] = "/etc/xl2tpd"

--- a/recipes/_enable_snat.rb
+++ b/recipes/_enable_snat.rb
@@ -2,7 +2,7 @@ public_interface = node['network']['interfaces'].detect { |k,v| v['addresses'].k
 
 execute "turn on public SNAT" do
   command "iptables -t nat -I POSTROUTING -o #{public_interface} -j SNAT --to #{node['ipaddress']}"
-  not_if "iptables -L -t nat | grep #{node['ipaddress']}"
+  not_if "iptables -L -t nat | grep #{node[:openswan][:public_ip]}"
   notifies :restart, "service[xl2tpd]"
   notifies :restart, "service[ipsec]"
 end

--- a/templates/default/ipsec.conf.erb
+++ b/templates/default/ipsec.conf.erb
@@ -25,7 +25,7 @@ conn L2TP-PSK-noNAT
     rekey=no
     type=transport
     ### NOTE:  "left" here is "the VPN server in the cloud".  Change this to your public IP.
-    left=<%= node[:ipaddress] %>
+    left=<%= node['openswan']['public_ip'] %>
     leftprotoport=17/1701
     right=%any
     rightprotoport=17/%any

--- a/templates/default/ipsec.conf.tunnel.erb
+++ b/templates/default/ipsec.conf.tunnel.erb
@@ -17,7 +17,7 @@ conn <%= connection %>
     pfs=no
     type=tunnel
 
-    left=<%= node['ipaddress'] %>
+    left=<%= node['openswan']['public_ip'] %>
     leftsubnets={<%= node['openswan']['tunnel']['connections'][connection]['local']['subnets'].join(' ') %>}
     leftnexthop=%defaultroute
 

--- a/templates/default/ipsec.secrets.erb
+++ b/templates/default/ipsec.secrets.erb
@@ -1,1 +1,1 @@
-<%= node[:ipaddress] %> %any: PSK "<%= node[:openswan][:preshared_key] %>"
+<%= node[:openswan][:public_ip] %> %any: PSK "<%= node[:openswan][:preshared_key] %>"


### PR DESCRIPTION
Incase there are multiple ethernet end points, the users should be able to set the public ip address, instead of giving the default eth0 node[:ipaddress].

As an example vagrant gives the eth0 to its local ip, and eth0 to the public network ip.
